### PR TITLE
chore: allow PHPUnit >=6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=7.0",
-    "phpunit/phpunit": "^6.1"
+    "phpunit/phpunit": "^6.0"
   },
   "license": "BSD-3-Clause",
   "authors": [


### PR DESCRIPTION
I ran an update with `composer update --prefer-lowest` and the test suite passes, can't test on the application as its fixed to 6.0.x still. 