### PR TITLE
Use PHPUnit's --filter option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=7.0",
-    "phpunit/phpunit": "^6.0"
+    "phpunit/phpunit": "^6.0|^7.0"
   },
   "license": "BSD-3-Clause",
   "authors": [

--- a/src/Git.php
+++ b/src/Git.php
@@ -65,14 +65,15 @@ class Git implements VCS
 
     public function getChangedFiles(): array
     {
-
+        $arguments = $_SERVER['argv'];
+        
+        $from = isset($arguments[1]) ? $arguments[1] : 'HEAD^';
+        $to = isset($arguments[2]) ? $arguments[2] : 'HEAD';
+        
         $changes = $this->execute("git diff --name-only");
         $changes .= PHP_EOL;
-
-        if ($this->countCommits() > 1) {
-            $changes .= $this->execute("git diff --name-only HEAD^ HEAD");
-        }
-
+        $changes .= $this->execute("git diff --name-only $from $to");
+        
         $changes = trim($changes);
         $files = explode(PHP_EOL, $changes);
         return $files;

--- a/src/Git.php
+++ b/src/Git.php
@@ -11,7 +11,7 @@ namespace IcyApril\WhatsChanged;
 
 class Git implements VCS
 {
-    private $binary = '/usr/bin/git';
+    private $binary = 'git';
 
     public function __construct($binary = "")
     {
@@ -24,7 +24,7 @@ class Git implements VCS
         }
 
         if ($this->gitExists() !== true) {
-            throw new GitException("Git doesn't appear to exist in: " . $this->binary);
+            throw new GitException($this->binary . " doesn't appear to exist in: " . $this->binary);
         }
 
         if ($this->isProjectGit() !== true) {
@@ -43,18 +43,12 @@ class Git implements VCS
 
     public function gitExists(): bool
     {
-        $returnVar = intval(trim(shell_exec($this->binary . " &> /dev/null; echo $?")));
-
-        if ($returnVar === 1) {
-            return true;
-        }
-
-        return false;
+        return !empty('which ' . $this->binary);
     }
 
     private function isProjectGit(): bool
     {
-        $isProjectGit = trim(shell_exec("git rev-parse --is-inside-work-tree"));
+        $isProjectGit = trim(shell_exec($this->binary . " rev-parse --is-inside-work-tree"));
 
         if ($isProjectGit === "true") {
             return true;
@@ -70,9 +64,9 @@ class Git implements VCS
         $from = isset($arguments[1]) ? $arguments[1] : 'HEAD^';
         $to = isset($arguments[2]) ? $arguments[2] : 'HEAD';
         
-        $changes = $this->execute("git diff --name-only");
+        $changes = $this->execute($this->binary . " diff --name-only");
         $changes .= PHP_EOL;
-        $changes .= $this->execute("git diff --name-only $from $to");
+        $changes .= $this->execute($this->binary . " diff --name-only $from $to");
         
         $changes = trim($changes);
         $files = explode(PHP_EOL, $changes);
@@ -81,7 +75,7 @@ class Git implements VCS
 
     private function countCommits(): int
     {
-        return intval(trim($this->execute("git shortlog | grep -E '^[ ]+\\w+' | wc -l")));
+        return intval(trim($this->execute($this->binary . " shortlog | grep -E '^[ ]+\\w+' | wc -l")));
     }
 
     private function execute(string $command): string

--- a/src/WhatsChanged.php
+++ b/src/WhatsChanged.php
@@ -23,8 +23,11 @@ class WhatsChanged
         $changes = $this->VCS->getChangedFiles();
         $testFiles = $this->getTestFiles($changes);
         
-        $regex = '(' . str_replace(['tests/', '/', '.php'], ['', '\\\\', ''], implode('|', $testFiles)) . ')';
+        if(empty($testFiles)) {
+            die('No tests to run' . PHP_EOL);
+        }
         
+        $regex = '(' . str_replace(['tests/', '/', '.php'], ['', '\\\\', ''], implode('|', $testFiles)) . ')';
         $exec = passthru("./vendor/bin/phpunit --filter '" . $regex . "'");
     }
 

--- a/src/WhatsChanged.php
+++ b/src/WhatsChanged.php
@@ -28,7 +28,8 @@ class WhatsChanged
         }
         
         $regex = '(' . str_replace(['tests/', '/', '.php'], ['', '\\\\', ''], implode('|', $testFiles)) . ')';
-        $exec = passthru("./vendor/bin/phpunit --filter '" . $regex . "'", $code);
+        
+        $exec = system("./vendor/bin/phpunit --filter '" . $regex . "'", $code);
         
         exit($code);
     }

--- a/src/WhatsChanged.php
+++ b/src/WhatsChanged.php
@@ -28,7 +28,9 @@ class WhatsChanged
         }
         
         $regex = '(' . str_replace(['tests/', '/', '.php'], ['', '\\\\', ''], implode('|', $testFiles)) . ')';
-        $exec = passthru("./vendor/bin/phpunit --filter '" . $regex . "'");
+        $exec = passthru("./vendor/bin/phpunit --filter '" . $regex . "'", $code);
+        
+        exit($code);
     }
 
     public function getTestFiles(array $changes): array

--- a/src/WhatsChanged.php
+++ b/src/WhatsChanged.php
@@ -22,25 +22,10 @@ class WhatsChanged
     {
         $changes = $this->VCS->getChangedFiles();
         $testFiles = $this->getTestFiles($changes);
-
-        $mask = "%-30s %-30s\n";
-
-        $fails = array();
-
-        foreach ($testFiles as $file) {
-            $exec = exec("./vendor/bin/phpunit " . $file, $full);
-
-            if (strpos($exec, 'OK ') !== false) {
-                printf($mask, $file, $exec);
-            } else {
-                printf($mask, $file, 'FAIL - '.$exec);
-                array_push($fails, implode(PHP_EOL, $full));
-            }
-        }
-
-        if (!empty($fails)) {
-            echo PHP_EOL.PHP_EOL."FAILED TEST OUTPUTS:".PHP_EOL.PHP_EOL.implode(" ", $fails).PHP_EOL.PHP_EOL;
-        }
+        
+        $regex = '(' . str_replace(['tests/', '/', '.php'], ['', '\\\\', ''], implode('|', $testFiles)) . ')';
+        
+        $exec = passthru("./vendor/bin/phpunit --filter '" . $regex . "'");
     }
 
     public function getTestFiles(array $changes): array


### PR DESCRIPTION
The current implementation executes the `phpunit` command once per test.
In our development context, we use bootstrapping (to reset our database and clear cache in a Symfony project), which adds an important overhead to this command.

So this change makes use of the `filter` option of PHPUnit to execute only one command. Because only one command is executed, I also removed the result parsing and launch the new command with `passthru`.

It might prove useful to other projects.

Also, I bumped the version of the PHPUnit dependency which fixes #4!